### PR TITLE
Fix/linux clipboard and BLE reconnect

### DIFF
--- a/linux/ui-tauri/src-tauri/Cargo.lock
+++ b/linux/ui-tauri/src-tauri/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
+ "wl-clipboard-rs",
  "x11rb",
 ]
 
@@ -1133,6 +1134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1339,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -2792,6 +2805,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,6 +3168,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3210,6 +3242,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -3315,7 +3358,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -3502,6 +3545,15 @@ name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -5091,6 +5143,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5315,6 +5378,7 @@ dependencies = [
  "tracing-subscriber",
  "vortex-l3-daemon",
  "walkdir",
+ "wl-clipboard-rs",
  "x11rb",
  "zbus 5.15.0",
  "zip",
@@ -5483,6 +5547,76 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.41.0",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -6153,6 +6287,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/linux/ui-tauri/src-tauri/Cargo.toml
+++ b/linux/ui-tauri/src-tauri/Cargo.toml
@@ -43,10 +43,23 @@ vortex-l3-daemon = { path = "../../daemon" }
 # Remember window size/position across restarts (auto save+restore).
 tauri-plugin-window-state = "2"
 tauri-plugin-single-instance = "2"
-arboard = "3.6.1"
+# `wayland-data-control` is NOT one of arboard's default features, and without
+# it arboard is X11-only on Linux — on a Wayland session it reads XWayland's
+# clipboard and depends on the compositor bridging the two selections. Measured
+# on Plasma 6/Wayland: it does not. A long-lived handle sat on a four-minute-old
+# value while `wl-paste` reported the truth, so laptop→phone clipboard sync only
+# fired on the rare copy the bridge happened to carry across. With the feature,
+# arboard talks wlr-data-control directly and tracks every change; X11 stays the
+# fallback when there is no Wayland display.
+arboard = { version = "3.6.1", features = ["wayland-data-control"] }
 # Already in the tree via arboard — used here to probe the CLIPBOARD selection's
 # `x-kde-passwordManagerHint` target so password-manager copies aren't synced.
 x11rb = "0.13"
+# Also already in the tree via arboard's `wayland-data-control`. The same
+# password-manager probe has to be answerable on the selection arboard actually
+# reads: once that is the Wayland one, an X11-only probe reads a stale selection
+# and would report "not secret" for a password copy it simply cannot see.
+wl-clipboard-rs = "0.9"
 image = { version = "0.25.6", default-features = false, features = ["png", "ico", "jpeg", "gif"] }
 # Screen mirroring (laptop receiver): decode the phone's sealed H.264 stream
 # into a native window. Links against the system GStreamer (1.20+).

--- a/linux/ui-tauri/src-tauri/src/ble.rs
+++ b/linux/ui-tauri/src-tauri/src/ble.rs
@@ -493,7 +493,32 @@ pub(crate) async fn connect_bonded_or_scan(
             return None;
         }
     };
-    match VortexClient::connect(adapter, addr).await {
+    // Capped, for the same reason the fast path above is capped — and this is
+    // the one that actually burns. Measured on a cold start: six doomed attempts
+    // at 13-18 s each, two minutes of dead time, then a connect that succeeded in
+    // under a second once the address was fresh.
+    //
+    // The address comes from a scan, but the phone rotates its presence RPA every
+    // 60 s. Uncapped, one doomed attempt plus the next 15 s scan is ~33 s — the
+    // same order as the rotation, so we spend most of the time dialling addresses
+    // the phone has already abandoned, and each failure costs a further rotation.
+    // Capping turns that into several short attempts per window, each on a fresher
+    // address. 8 s is well above a healthy connect-plus-service-discovery (the
+    // fast path expects sub-second on a known-good RPA) and well below the 13-18 s
+    // a dead RPA was costing.
+    const CONNECT_CAP: Duration = Duration::from_secs(8);
+    let connect = match tokio::time::timeout(CONNECT_CAP, VortexClient::connect(adapter, addr)).await
+    {
+        Ok(r) => r,
+        // A tokio timeout drops the future, but BlueZ keeps the connect attempt in
+        // flight — the next connect to a different RPA would fail "In Progress".
+        // `clear_pending_connect` in the error arm below cancels it, so route the
+        // timeout through the same cleanup rather than duplicating it.
+        Err(_) => Err(vortex_l3_daemon::core::ble::client::ClientError::Timeout(
+            "connect (capped)",
+        )),
+    };
+    match connect {
         Ok(client) => {
             *last_rpa = Some(addr);
             *consec_connect_fail = 0;

--- a/linux/ui-tauri/src-tauri/src/clipboard.rs
+++ b/linux/ui-tauri/src-tauri/src/clipboard.rs
@@ -293,11 +293,41 @@ fn poll_once(cb: &mut arboard::Clipboard, last_sig: &mut String, last_state: &mu
 /// password. We ask the CLIPBOARD owner to convert to that target: if it's
 /// offered, the copy is secret → don't store or sync it.
 ///
-/// X11/XWayland only (arboard already proves the bridge works on the GNOME
-/// target). Fails OPEN on ANY error — a probe failure must never silently halt
-/// normal clipboard sync. One persistent connection + owned window, lazily
-/// built; the round-trip happens only when the text actually changed.
+/// Fails OPEN on ANY error — a probe failure must never silently halt normal
+/// clipboard sync.
+///
+/// It has to ask about the SAME selection arboard reads, or it answers about
+/// text that was never captured. Under Wayland those are two different
+/// selections: arboard (with `wayland-data-control`) reads the Wayland one,
+/// while the X11 probe below sees whatever XWayland last got handed — which on
+/// Plasma is frequently minutes stale. An X11-only probe would then report "not
+/// secret" for a password copy it simply cannot see, and the password would sync
+/// to the phone. So Wayland is asked first, on Wayland's own terms.
+
+/// The Wayland arm: list the MIME types the selection offers and look for the
+/// hint among them. Cheaper than the X11 round trip — no conversion request,
+/// the compositor already knows the offer's type list.
+///
+/// `None` means "could not ask" (no Wayland display, no data-control protocol),
+/// which hands the question to the X11 probe rather than answering it wrongly.
+fn wayland_clipboard_is_secret() -> Option<bool> {
+    use wl_clipboard_rs::paste::{get_mime_types, ClipboardType, Seat};
+
+    if std::env::var_os("WAYLAND_DISPLAY").is_none() {
+        return None;
+    }
+    match get_mime_types(ClipboardType::Regular, Seat::Unspecified) {
+        Ok(types) => Some(types.iter().any(|t| t == "x-kde-passwordManagerHint")),
+        // An empty clipboard is a definite "not secret", not a failure to ask.
+        Err(wl_clipboard_rs::paste::Error::ClipboardEmpty) => Some(false),
+        Err(_) => None,
+    }
+}
+
 fn clipboard_is_secret() -> bool {
+    if let Some(secret) = wayland_clipboard_is_secret() {
+        return secret;
+    }
     use x11rb::connection::Connection;
     use x11rb::protocol::xproto::{
         AtomEnum, ConnectionExt, CreateWindowAux, WindowClass,

--- a/linux/ui-tauri/src-tauri/src/clipboard_sync.rs
+++ b/linux/ui-tauri/src-tauri/src/clipboard_sync.rs
@@ -30,6 +30,19 @@ pub(crate) type ClipboardWriter = std::sync::Arc<
         + Sync,
 >;
 
+/// How often an undelivered copy is re-offered to the link.
+///
+/// Only does work when something is actually pending, so the cost of a short
+/// period is one comparison every couple of seconds.
+const RETRY_EVERY: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// How long an undelivered copy keeps trying before it is abandoned.
+///
+/// Long enough to outlast every ordinary gap — the BLE reconnect backoff caps
+/// at 60 s, plus scan time — and short enough that a copy made before lunch
+/// does not silently overwrite the phone's clipboard on the next reconnect.
+const PENDING_TTL: std::time::Duration = std::time::Duration::from_secs(300);
+
 /// Whether laptop↔phone clipboard sync is on. Default ON (user decision).
 /// Local toggle in Settings; checked by both the send and receive paths.
 pub(crate) static CLIPBOARD_SYNC: AtomicBool = AtomicBool::new(true);
@@ -208,27 +221,58 @@ pub(crate) fn spawn_clipboard_sync(
     {
         let writer = writer.clone();
         tokio::spawn(async move {
-            while let Some(text) = send_rx.recv().await {
-                if !CLIPBOARD_SYNC.load(Ordering::Relaxed) {
+            // The newest copy that has not reached the phone yet.
+            //
+            // One slot rather than a queue, because a clipboard is
+            // last-write-wins: if three things were copied while the link was
+            // down, the phone wants the third — not all three arriving in a
+            // burst, with the oldest landing last.
+            let mut pending: Option<(String, String, std::time::Instant)> = None;
+            let mut retry = tokio::time::interval(RETRY_EVERY);
+            retry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                tokio::select! {
+                    got = send_rx.recv() => {
+                        let Some(text) = got else { break };
+                        if !CLIPBOARD_SYNC.load(Ordering::Relaxed) {
+                            continue;
+                        }
+                        let sig = sync_sig(&text);
+                        // Loop guard: don't bounce back what we just set from a
+                        // received sync.
+                        if LAST_SYNC_SIG.lock().map(|g| *g == sig).unwrap_or(false) {
+                            continue;
+                        }
+                        pending = Some((text, sig, std::time::Instant::now()));
+                    }
+                    _ = retry.tick() => {}
+                }
+                let Some((text, sig, queued_at)) = pending.clone() else { continue };
+                if queued_at.elapsed() > PENDING_TTL {
+                    tracing::info!("clipboard: copy too old to sync; dropped");
+                    pending = None;
                     continue;
                 }
-                let sig = sync_sig(&text);
-                // Loop guard: don't bounce back what we just set from a
-                // received sync.
-                if LAST_SYNC_SIG.lock().map(|g| *g == sig).unwrap_or(false) {
-                    continue;
-                }
-                let Some(w) = writer.lock().await.clone() else {
-                    continue; // no live link — drop (ephemeral)
-                };
+                // BLE is the ONLY laptop→phone clipboard transport (LAN carries
+                // the phone→laptop direction and images), and this writer exists
+                // only while the GATT link is up. It used to `continue` here and
+                // drop the copy, so anything copied while the link was down —
+                // reconnect backoff, an RPA rotation, the phone's screen off —
+                // vanished with no trace. That is why roughly one copy in ten
+                // arrived: the ones that happened to coincide with a live link.
+                // Now it waits for the link instead.
+                let Some(w) = writer.lock().await.clone() else { continue };
                 match w(ClipboardMirror::new(text, now_ms())).await {
                     Ok(()) => {
+                        pending = None;
                         if let Ok(mut g) = LAST_SYNC_SIG.lock() {
                             *g = sig;
                         }
                         tracing::debug!("→ clipboard synced to phone");
                     }
-                    Err(e) => tracing::warn!("clipboard sync send failed: {e}"),
+                    // Stays pending: a write that failed on a link which was up
+                    // a moment ago is the case most worth another attempt.
+                    Err(e) => tracing::warn!("clipboard sync send failed (will retry): {e}"),
                 }
             }
         });
@@ -274,24 +318,44 @@ pub(crate) fn spawn_clipboard_sync(
     {
         let img_writer = img_writer.clone();
         tokio::spawn(async move {
-            while let Some((sig, png)) = img_send_rx.recv().await {
-                if !CLIPBOARD_SYNC.load(Ordering::Relaxed) {
+            // Same hold-the-newest rule as the text path above, and the same
+            // reason. One image at a time: these are already capped at
+            // `MAX_BLE_IMAGE_BYTES`, so a single slot is bounded memory.
+            let mut pending: Option<(String, Vec<u8>, std::time::Instant)> = None;
+            let mut retry = tokio::time::interval(RETRY_EVERY);
+            retry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                tokio::select! {
+                    got = img_send_rx.recv() => {
+                        let Some((sig, png)) = got else { break };
+                        if !CLIPBOARD_SYNC.load(Ordering::Relaxed) {
+                            continue;
+                        }
+                        if LAST_SYNC_IMG.lock().map(|g| *g == sig).unwrap_or(false) {
+                            continue; // loop guard — just set from a received sync
+                        }
+                        pending = Some((sig, png, std::time::Instant::now()));
+                    }
+                    _ = retry.tick() => {}
+                }
+                let Some((sig, png, queued_at)) = pending.clone() else { continue };
+                if queued_at.elapsed() > PENDING_TTL {
+                    tracing::info!("clipboard: copied image too old to sync; dropped");
+                    pending = None;
                     continue;
                 }
-                if LAST_SYNC_IMG.lock().map(|g| *g == sig).unwrap_or(false) {
-                    continue; // loop guard — just set from a received sync
-                }
-                let Some(w) = img_writer.lock().await.clone() else {
-                    continue; // no live link
-                };
+                let Some(w) = img_writer.lock().await.clone() else { continue };
                 match w(png).await {
                     Ok(()) => {
+                        pending = None;
                         if let Ok(mut g) = LAST_SYNC_IMG.lock() {
                             *g = sig;
                         }
                         tracing::debug!("→ clipboard image synced to phone");
                     }
-                    Err(e) => tracing::warn!("clipboard image sync send failed: {e}"),
+                    Err(e) => {
+                        tracing::warn!("clipboard image sync send failed (will retry): {e}")
+                    }
                 }
             }
         });

--- a/linux/ui-tauri/src-tauri/src/lan.rs
+++ b/linux/ui-tauri/src-tauri/src/lan.rs
@@ -995,6 +995,10 @@ pub(crate) fn spawn_heartbeat(
             let auto_ble_writers = ble_audio_writers.clone();
             tokio::spawn(async move {
                 let mut consec_lan_fail = 0u32;
+                // Distinct from `consec_lan_fail == 0`, which cannot tell "the
+                // last attempt succeeded" from "there has not been one yet" —
+                // and the difference is the whole cold start. See the nudge below.
+                let mut lan_ever_synced = false;
                 loop {
                     let (had_trust, lan_synced) = {
                         let _g = auto_lock_clone.lock().await;
@@ -1049,11 +1053,26 @@ pub(crate) fn spawn_heartbeat(
                         // Edge-triggered on purpose: a steady-state LAN tick
                         // must not poke BLE every cycle when the phone simply
                         // has Bluetooth off.
-                        if consec_lan_fail > 0 {
+                        // The FIRST sync after launch is a down→up edge too,
+                        // and the one that matters most: at startup the BLE loop
+                        // has no learned RPA, so it cannot take its direct-connect
+                        // fast path and instead sits in presence discovery
+                        // (monitor registration, or 15 s scans backing off
+                        // 5→10→20→45 s). Meanwhile LAN is up in about two
+                        // seconds and knows the phone is right there.
+                        //
+                        // `consec_lan_fail > 0` alone could not see that edge,
+                        // because the counter starts at 0 and a first success
+                        // leaves it at 0 — so the nudge never fired on a cold
+                        // start and BLE rode out the full wait. Everything that
+                        // rides BLE and only BLE was dead until it finished:
+                        // clipboard text, in BOTH directions.
+                        if consec_lan_fail > 0 || !lan_ever_synced {
                             if let Some(n) = crate::BLE_RETRY_NUDGE.get() {
                                 n.notify_one();
                             }
                         }
+                        lan_ever_synced = true;
                         consec_lan_fail = 0;
                     } else if had_trust {
                         consec_lan_fail = consec_lan_fail.saturating_add(1);

--- a/linux/ui-tauri/src-tauri/src/lan_state.rs
+++ b/linux/ui-tauri/src-tauri/src/lan_state.rs
@@ -127,6 +127,7 @@ pub(crate) fn dispatch_appstate_call(
 
 pub(crate) fn spawn_state_consumer(
     app: AppHandle,
+    peer_store: std::sync::Arc<dyn vortex_l3_daemon::core::storage::peers::PeerStore>,
 ) -> tokio::sync::mpsc::UnboundedSender<([u8; 32], vortex_l3_daemon::core::appstate::AppState)> {
             let (ble_state_tx, mut ble_state_rx) = tokio::sync::mpsc::unbounded_channel::<(
                 [u8; 32],
@@ -134,6 +135,7 @@ pub(crate) fn spawn_state_consumer(
             )>();
             {
                 let app_state = app.clone();
+                let peer_store = peer_store.clone();
                 tokio::spawn(async move {
                     use tauri::Emitter;
                     // One bluer adapter for the whole consumer (a fresh
@@ -156,6 +158,25 @@ pub(crate) fn spawn_state_consumer(
                         // BLE-carried hint is the only way the cache tracks a
                         // DHCP renew / network change.
                         crate::lan::note_peer_reported_ip(&state);
+                        // Bidirectional forget, on THIS path too. The phone sets
+                        // `revoked` in the snapshot it pushes over both
+                        // transports, but only the LAN heartbeat in `lan.rs` was
+                        // acting on it — so forgetting the laptop on the phone
+                        // left the laptop still trusting it whenever the revoke
+                        // did not happen to land over LAN inside the phone's
+                        // 1.5 s grace window (different network, mDNS not yet
+                        // resolved, or simply a BLE-only moment). BLE carries
+                        // the same flag reliably; honour it here and stop
+                        // reading the peer's own snapshots afterwards.
+                        if state.revoked {
+                            tracing::info!(
+                                "peer revoked us (via BLE); forgetting {}",
+                                hex::encode(&peer_pub[..8])
+                            );
+                            let _ = peer_store.forget(&peer_pub);
+                            crate::emit_peers(&app_state, peer_store.clone()).await;
+                            continue;
+                        }
                         // Vue UI — identical event to the LAN heartbeat path.
                         // Also feed the call carried in this STATE frame (a
                         // backstop if a dedicated CALL frame was dropped).

--- a/linux/ui-tauri/src-tauri/src/worker.rs
+++ b/linux/ui-tauri/src-tauri/src/worker.rs
@@ -244,7 +244,8 @@ pub(crate) fn run_worker(app: AppHandle, cmd_rx: Receiver<UiCmd>) {
         // a consumer task applies it to the UI instantly — the same Vue
         // event + tray refresh a LAN heartbeat produces, but in ~200 ms over
         // the already-open BLE link instead of a fresh TCP+IK reconnect.
-        let ble_state_tx = crate::lan_state::spawn_state_consumer(app.clone());
+        let ble_state_tx =
+            crate::lan_state::spawn_state_consumer(app.clone(), peer_store.clone());
 
         // BLE notification-mirror channel: the persistent listener forwards
         // a decoded NotificationMirror here; a consumer pops it as a desktop


### PR DESCRIPTION
This one is a combination of fixes for both issues I've found in the software usage. 
The first issue is the very slow BLE reconnect (when leaving and coming back) that can take more than 5mn to happen. This is due to the phone having rotated its RPA and thus lost its sync with the laptop. The commit reduces the reconnect time to something more manageable (around 1mn).

The second fix is an issue with clipboard not sent to the phone when using Wayland and BLE is reconnecting (lost clipboard content in that case). 