### PR TITLE
Fixing pairing issues on KDE

### DIFF
--- a/android/app/src/main/java/com/vortex/a3/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/vortex/a3/ui/MainActivity.kt
@@ -265,12 +265,10 @@ class MainActivity : ComponentActivity() {
         }
         intent.getStringExtra("remove_bond")?.let { mac ->
             val adapter = getSystemService(android.bluetooth.BluetoothManager::class.java)?.adapter
-            val ok = adapter?.let {
-                com.vortex.a3.core.ble.BondCleaner.removeBond(it, mac)
-            } ?: false
-            android.widget.Toast.makeText(
-                this, "removeBond($mac) = $ok", android.widget.Toast.LENGTH_LONG
-            ).show()
+            // Result is not shown on screen: BondCleaner already logs it
+            // ("VortexBondCleaner: removeBond(<mac>) -> <ok>"), and a toast on
+            // top of the pairing UI got in the way while live-debugging bonds.
+            adapter?.let { com.vortex.a3.core.ble.BondCleaner.removeBond(it, mac) }
         }
     }
 

--- a/linux/daemon/src/core/storage/mod.rs
+++ b/linux/daemon/src/core/storage/mod.rs
@@ -68,6 +68,11 @@ where
 pub enum StorageError {
     NotFound,
     Backend(String),
+    /// The desktop keyring is locked and the unlock was refused, dismissed,
+    /// or impossible (no prompter on the session bus). Distinct from
+    /// [`Self::Backend`] because it is the one storage failure the *user*
+    /// can fix, so callers surface it instead of dying silently.
+    Locked(String),
 }
 
 impl std::fmt::Display for StorageError {
@@ -75,6 +80,7 @@ impl std::fmt::Display for StorageError {
         match self {
             Self::NotFound => write!(f, "not found"),
             Self::Backend(msg) => write!(f, "backend error: {msg}"),
+            Self::Locked(msg) => write!(f, "keyring locked: {msg}"),
         }
     }
 }
@@ -82,6 +88,56 @@ impl std::fmt::Display for StorageError {
 impl std::error::Error for StorageError {}
 
 pub type StorageResult<T> = Result<T, StorageError>;
+
+/// Fetch the default collection, unlocking it first when the session's
+/// keyring has it locked.
+///
+/// **Why this is not just `get_default_collection()`:** that call succeeds
+/// on a *locked* collection — only the write that follows fails, with
+/// `org.freedesktop.Secret.Error.IsLocked`. So the availability probe in
+/// each store's `new()` passes and the process dies later, at first save,
+/// with an error nobody attributes to the keyring.
+///
+/// That is the *normal* state on any session whose `default` alias points
+/// at a keyring PAM does not unlock at login. Live-hit on Manjaro/KDE
+/// 2026-08-25: gnome-keyring owned `org.freedesktop.secrets` (its D-Bus
+/// service file wins over KDE's ksecretd), its `login` keyring was
+/// unlocked, but the `default` alias pointed at a second, password-
+/// protected keyring. Identity init failed, the Tauri worker returned
+/// before it ever opened the BLE adapter, and the pairing radar sat
+/// silently empty — the phone was advertising correctly the whole time.
+///
+/// [`secret_service::Collection::unlock`] drives the Secret Service
+/// Unlock + Prompt handshake, so the desktop's own prompter asks for the
+/// password (gcr on GNOME, ksecretd/KWallet on KDE). Two constraints
+/// follow from the D-Bus API and both are satisfied by construction here:
+///
+/// 1. The prompt object is owned by the **calling connection** and is
+///    destroyed with it, so the unlock must share one connection with the
+///    write it enables — i.e. live inside the same [`secret_block_on`]
+///    future. (Splitting them across two `busctl` calls fails with
+///    "no such object", which is how this was first confirmed.)
+/// 2. It costs one extra round trip, not a prompt, once the collection is
+///    unlocked: the service returns the path in `unlocked` and
+///    `lock_or_unlock` skips the prompt entirely. Safe to call before
+///    every write rather than tracking unlock state ourselves.
+// `::secret_service` — the absolute crate path is required here: the sibling
+// module `storage::secret_service` shadows the crate name inside this module.
+pub(crate) async fn unlocked_default_collection<'a>(
+    service: &'a ::secret_service::SecretService<'a>,
+) -> StorageResult<::secret_service::Collection<'a>> {
+    let collection = service
+        .get_default_collection()
+        .await
+        .map_err(|e| StorageError::Backend(format!("default collection: {e}")))?;
+    if collection.is_locked().await.unwrap_or(false) {
+        collection
+            .unlock()
+            .await
+            .map_err(|e| StorageError::Locked(format!("unlock refused or unavailable: {e}")))?;
+    }
+    Ok(collection)
+}
 
 /// Storage backend for local Vortex identity (private + public material).
 ///

--- a/linux/daemon/src/core/storage/peers.rs
+++ b/linux/daemon/src/core/storage/peers.rs
@@ -15,7 +15,7 @@ use std::sync::Mutex;
 
 use secret_service::{EncryptionType, SecretService};
 
-use super::{StorageError, StorageResult};
+use super::{unlocked_default_collection, StorageError, StorageResult};
 
 const SCHEMA: &str = "com.vortex.peer.v1";
 const LABEL: &str = "Vortex V1 trusted peer";
@@ -297,10 +297,7 @@ impl SecretServicePeerStore {
             let svc = SecretService::connect(EncryptionType::Dh)
                 .await
                 .map_err(|e| StorageError::Backend(format!("connect: {e}")))?;
-            let coll = svc
-                .get_default_collection()
-                .await
-                .map_err(|e| StorageError::Backend(format!("collection: {e}")))?;
+            let coll = unlocked_default_collection(&svc).await?;
             let mut search = svc
                 .search_items(attrs_ref.clone())
                 .await
@@ -367,10 +364,7 @@ impl PeerStore for SecretServicePeerStore {
             let svc = SecretService::connect(EncryptionType::Dh)
                 .await
                 .map_err(|e| StorageError::Backend(format!("connect: {e}")))?;
-            let coll = svc
-                .get_default_collection()
-                .await
-                .map_err(|e| StorageError::Backend(format!("collection: {e}")))?;
+            let coll = unlocked_default_collection(&svc).await?;
             // Dedupe: explicitly remove any prior items for this
             // peer_static_pub before creating. The `replace=true` flag
             // on create_item alone is unreliable across Secret Service
@@ -613,10 +607,7 @@ impl PeerStore for SecretServicePeerStore {
             let svc = SecretService::connect(EncryptionType::Dh)
                 .await
                 .map_err(|e| StorageError::Backend(format!("connect: {e}")))?;
-            let coll = svc
-                .get_default_collection()
-                .await
-                .map_err(|e| StorageError::Backend(format!("collection: {e}")))?;
+            let coll = unlocked_default_collection(&svc).await?;
             // Single-record upsert: drop any existing then create one.
             let mut existing = svc
                 .search_items(attrs_ref)
@@ -653,10 +644,7 @@ impl PeerStore for SecretServicePeerStore {
             let svc = SecretService::connect(EncryptionType::Dh)
                 .await
                 .map_err(|e| StorageError::Backend(format!("connect: {e}")))?;
-            let coll = svc
-                .get_default_collection()
-                .await
-                .map_err(|e| StorageError::Backend(format!("collection: {e}")))?;
+            let coll = unlocked_default_collection(&svc).await?;
             // Read current.
             let mut search = svc
                 .search_items(attrs_ref.clone())

--- a/linux/daemon/src/core/storage/secret_service.rs
+++ b/linux/daemon/src/core/storage/secret_service.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 
 use secret_service::{EncryptionType, SecretService};
 
-use super::{IdentityStore, StorageError, StorageResult};
+use super::{unlocked_default_collection, IdentityStore, StorageError, StorageResult};
 use crate::core::crypto::x25519::{X25519Pub, X25519Sec, X25519SecBytes};
 use crate::core::identity::{IdentityRecord, Platform, IDENTITY_VERSION};
 
@@ -97,10 +97,7 @@ impl IdentityStore for SecretServiceIdentityStore {
             let service = SecretService::connect(EncryptionType::Dh)
                 .await
                 .map_err(|e| StorageError::Backend(format!("connect: {e}")))?;
-            let collection = service
-                .get_default_collection()
-                .await
-                .map_err(|e| StorageError::Backend(format!("collection: {e}")))?;
+            let collection = unlocked_default_collection(&service).await?;
             collection
                 .create_item(LABEL, attrs(), &payload, true /* replace */, CONTENT_TYPE)
                 .await


### PR DESCRIPTION
On another laptop running KDE, I had both gnome's keyring and KDE keyring installed, with my KDE keyring being the default (and locked). Vortex will display its scan page, but couldn't find the phone.

While debugging, it appeared that Vortex is expected the keyring to be unlocked to write to it directly. This PR patches this *invalid* assumption, if the keyring is locked, unlock it (likely asking User's password for that), and upon success, write to it.

Another (cosmetic) issue was the "removeBond" toast that appeared continuously. Let's log it, but don't toast it on the Android screen.

These commits are authored by Claude.